### PR TITLE
Spread a bit of LDAP_DEPRECATED love.

### DIFF
--- a/add-modify-delete.go
+++ b/add-modify-delete.go
@@ -29,6 +29,7 @@ package openldap
 
 /* #include <stdlib.h>
 #include <stdio.h>
+#define LDAP_DEPRECATED 1
 #include <ldap.h>
 
 // goc can not use union on structs ; so create a new type with same attributes and size

--- a/openldap.go
+++ b/openldap.go
@@ -35,6 +35,7 @@ package openldap
 
 /*
 
+#define LDAP_DEPRECATED 1
 #include <stdlib.h>
 #include <ldap.h>
 


### PR DESCRIPTION
This is needed to compile the openldap module under more recent OpenLDAP versions.
